### PR TITLE
Make it available for multiple instance

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -56,18 +56,18 @@ function extendApp(app) {
 
 function Router(app) {
   if (this instanceof Router) {
+    /**
+     * cache for ``Route`` objects
+     */
+
+    this.routes = [];
+    // exend passed app with koa-routing`` methods
+    extendApp.call(this, app);
     return this;
   }
   assert(app, 'You must provide app instance to use routing');
 
-  /**
-   * cache for ``Route`` objects
-   */
 
-  this.routes = [];
-
-  // exend passed app with koa-routing`` methods
-  extendApp.call(this, app);
 
   // return middleware for dispatching requests
   return new Router(app).middleware();

--- a/test/index.js
+++ b/test/index.js
@@ -6,12 +6,14 @@ var koa = require('koa'),
   routing = require('..');
 
 var app = koa(),
+  app2 = koa(),
   users;
 
 describe('router is', function () {
 
   before(function () {
     app.use(routing(app)).should.be.ok;
+    app2.use(routing(app2)).should.be.ok;
     users = app.route('/users');
 
     users.get(function * (next) {
@@ -77,6 +79,13 @@ describe('router is', function () {
         this.status = 300;
       })
       .get(function * (next) {
+        this.body = 'should not be here';
+        this.status = 200;
+        yield next;
+      });
+
+    app2.route('/app2')
+      .get(function * (next){
         this.body = 'should not be here';
         this.status = 200;
         yield next;
@@ -179,6 +188,21 @@ describe('router is', function () {
       request(app.listen())
         .get('/multipleMiddleware')
         .expect('2')
+        .expect(200, done);
+    });
+  });
+
+  describe('going into /app2 with app', function () {
+    it('will be error expected for GET /app2', function (done) {
+      request(app.listen())
+        .get('/app2')
+        .expect(404, done);
+    });
+  });
+  describe('going into /app2 with app2', function () {
+    it('should GET /app2', function (done) {
+      request(app2.listen())
+        .get('/app2')
         .expect(200, done);
     });
   });


### PR DESCRIPTION
When I using koa-routing and koa-vhost(https://github.com/Jeremial/koa-vhost) together, I found that, routes in different vhost are mixed.
So I changed routes variables as a property of Router's instance.
